### PR TITLE
add support for nested console messages

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,6 +175,17 @@ mod transform_visitor_tests {
 
     test!(
         ::swc_ecma_parser::Syntax::default(),
+        |_| transform_visitor(Config {
+            filename: Some("test.js".to_owned()),
+            ..Default::default()
+        }),
+        adds_prefix_when_nested,
+        r#"console.log("hello world", console.log("hello world"));"#,
+        r#"console.log("test.js", "hello world", console.log("test.js", "hello world"));"#
+    );
+
+    test!(
+        ::swc_ecma_parser::Syntax::default(),
         |_| transform_visitor(Default::default()),
         does_not_alter_console_table,
         r#"console.table(["apples", "oranges", "bananas"]);"#,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,7 @@ impl VisitMut for TransformVisitor {
     noop_visit_mut_type!();
 
     fn visit_mut_call_expr(&mut self, call_expr: &mut CallExpr) {
+        call_expr.visit_mut_children_with(self);
         if let Callee::Expr(expr) = &call_expr.callee {
             if let Expr::Member(member_expr) = &**expr {
                 if let (Expr::Ident(obj_id), MemberProp::Ident(prop_id)) =


### PR DESCRIPTION
this very important pr will allow adding prefixes for nested console.log messages e.g.:

```js
 console.log("hey", console.log("hi"))
```